### PR TITLE
Fix Jython memory leak

### DIFF
--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonBindings.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonBindings.java
@@ -31,8 +31,10 @@
 
 package org.scijava.plugins.scripting.jython;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -42,6 +44,7 @@ import javax.script.Bindings;
 
 import org.python.core.PyStringMap;
 import org.python.util.PythonInterpreter;
+import org.scijava.script.ScriptModule;
 
 /**
  * A {@link Bindings} wrapper around Jython's local variables.
@@ -51,6 +54,9 @@ import org.python.util.PythonInterpreter;
 public class JythonBindings implements Bindings {
 
 	protected final PythonInterpreter interpreter;
+
+	private Map<String, WeakReference<Object>> shallowMap =
+		new HashMap<String, WeakReference<Object>>();
 
 	public JythonBindings(final PythonInterpreter interpreter) {
 		this.interpreter = interpreter;
@@ -81,6 +87,10 @@ public class JythonBindings implements Bindings {
 
 	@Override
 	public Object get(Object key) {
+		if (shallowMap.containsKey(key)) {
+			return shallowMap.get(key).get();
+		}
+
 		try {
 			return interpreter.get((String)key);
 		} catch (Error e) {
@@ -91,18 +101,28 @@ public class JythonBindings implements Bindings {
 	@Override
 	public Object put(String key, Object value) {
 		final Object result = get(key);
-		try {
-			interpreter.set(key, value);
-		} catch (Error e) {
-			// ignore
+
+		if (value instanceof ScriptModule || value instanceof JythonScriptEngine){
+			shallowMap.put(key, new WeakReference<Object>(value));
 		}
+		else {
+			try {
+				interpreter.set(key, value);
+			}
+			catch (Error e) {
+				// ignore
+			}
+		}
+
 		return result;
 	}
 
 	@Override
 	public Object remove(Object key) {
 		final Object result = get(key);
-		if (result != null) interpreter.getLocals().__delitem__((String)key);
+		if (shallowMap.containsKey(key)) shallowMap.remove(key);
+		else if (result != null) interpreter.getLocals().__delitem__((String)key);
+
 		return result;
 	}
 

--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonBindings.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonBindings.java
@@ -55,6 +55,22 @@ public class JythonBindings implements Bindings {
 
 	protected final PythonInterpreter interpreter;
 
+	/*
+	 * NB: In our JythonScriptLanguage we explain the need for cleaning
+	 * up after a PythonInterpreter and declare the scope of a
+	 * Python environment to be equal to the lifetime of its parent
+	 * JythonScriptEngine.
+	 * As triggering our cleaning method involves PhantomReferences
+	 * we must ensure that JythonScriptEngines can actually be
+	 * garbage collected when it is no longer in use.
+	 * To do this, we have to prevent JythonScriptEngines from
+	 * being passed to the PythonInterpreter - which would then
+	 * create a hard reference to the ScriptEngine through the
+	 * static PySystemState.
+	 * Similarly we do not want to pass ScriptModules to the
+	 * PythonInterpreter, as the ScriptModule has a hard
+	 * reference to its ScriptEngine.
+	 */
 	private Map<String, WeakReference<Object>> shallowMap =
 		new HashMap<String, WeakReference<Object>>();
 

--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonReferenceCleaner.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonReferenceCleaner.java
@@ -1,0 +1,172 @@
+/*
+ * #%L
+ * JSR-223-compliant Jython scripting language plugin.
+ * %%
+ * Copyright (C) 2008 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.plugins.scripting.jython;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.python.core.PyObject;
+import org.python.util.PythonInterpreter;
+import org.scijava.log.LogService;
+import org.scijava.thread.ThreadService;
+
+/**
+ * A helper class for purging dangling references within a Jython interpreter
+ * after it executes a script.
+ * 
+ * @author Mark Hiner
+ */
+public class JythonReferenceCleaner {
+
+	// List of PhantomReferences and corresponding ReferenceQueue to
+	// facilitate proper PhantomReference use.
+	// See http://resources.ej-technologies.com/jprofiler/help/doc/index.html
+
+	private final LinkedList<JythonEnginePhantomReference> phantomReferences =
+		new LinkedList<JythonEnginePhantomReference>();
+	private final ReferenceQueue<JythonScriptEngine> queue =
+		new ReferenceQueue<JythonScriptEngine>();
+
+	/** Queues the future cleanup operation on a separate thread, */
+	public synchronized void queueCleanup(final JythonScriptEngine engine,
+		final ThreadService threadService, final LogService log)
+	{
+		// NB: This phantom reference is used to clean up any local variables
+		// created by evaluation of scripts via this ScriptEngine. We need
+		// to use PhantomReferences because the "scope" of a script extends
+		// beyond its eval method - a consumer may still want to inspect
+		// the state of variables after evaluation.
+		// By using PhantomReferences we are saying that the scope of 
+		// script evaluation equals the lifetime of the ScriptEngine.
+		phantomReferences.add(new JythonEnginePhantomReference(engine, queue));
+
+		// NB: The use of PhantomReferences requires a paired polling thread.
+		// We poll instead of blocking for input to avoid leaving lingering
+		// threads that would need to be interrupted - instead only starting
+		// threads running when there is actually a PhantomReference that
+		// will eventually be enqueued.
+		// Here we check if there is already a polling thread in operation -
+		// if not, we start a new thread.
+		if (phantomReferences.size() == 1) {
+			threadService.run(new Runnable() {
+
+				@Override
+				public void run() {
+					boolean done = false;
+
+					// poll the queue
+					while (!done) {
+						try {
+							Thread.sleep(100);
+
+							synchronized (JythonReferenceCleaner.this) {
+								// poll the queue
+								JythonEnginePhantomReference ref =
+										(JythonEnginePhantomReference) queue.poll();
+
+								// if we have a ref, clean it up
+								if (ref != null) {
+									ref.cleanup();
+									phantomReferences.remove(ref);
+								}
+
+								// Once we're done with our known phantom refs
+								// we can let this thread shut down
+								done = phantomReferences.size() == 0;
+							}
+
+						}
+						catch (final Exception ex) {
+							// log exception, continue
+							log.error(ex);
+						}
+					}
+				}
+			});
+		}
+	}
+
+	// -- Helper classes --
+
+	/**
+	 * Helper class to clean up {@link PythonInterpreter} local variables when a
+	 * parent {@link JythonScriptEngine} leaves scope.
+	 */
+	private static class JythonEnginePhantomReference extends
+		PhantomReference<JythonScriptEngine>
+	{
+
+		public PythonInterpreter interpreter;
+
+		public JythonEnginePhantomReference(JythonScriptEngine engine,
+			ReferenceQueue<JythonScriptEngine> queue)
+		{
+			super(engine, queue);
+			interpreter = engine.interpreter;
+		}
+
+		public void cleanup() {
+			final List<String> scriptLocals = new ArrayList<String>();
+			PythonInterpreter interp = interpreter;
+			if (interp == null) return;
+
+			// NB: This method for cleaning up local variables was taken from:
+			// http://python.6.x6.nabble.com/Cleaning-up-PythonInterpreter-object-td1777184.html
+			// Because Python is an interpreted language, when a Python script creates new
+			// variables they stick around in a static org.python.core.PySystemState  variable
+			// (defaultSystemState) the org.python.core.Py class.
+			// Thus an implicit static state is created by script evaluation, so we must manually
+			// clean up local variables known to the interpreter when the scope of an executed
+			// script is over.
+			// See original bug report for the memory leak that prompted this solution:
+			// http://fiji.sc/bugzilla/show_bug.cgi?id=1203
+			final PyObject locals = interp.getLocals();
+			for (final PyObject item : locals.__iter__().asIterable()) {
+				final String localVar = item.toString();
+				// Ignore __name__ and __doc__ variables, which are special and known not
+				// to be local variables created by evaluation.
+				if (!localVar.contains("__name__") && !localVar.contains("__doc__")) {
+					// Build list of variables to clean
+					scriptLocals.add(item.toString());
+				}
+			}
+			// Null out local variables
+			for (final String string : scriptLocals) {
+				interp.set(string, null);
+			}
+		}
+	}
+
+}

--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonReferenceCleaner.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonReferenceCleaner.java
@@ -95,8 +95,8 @@ public class JythonReferenceCleaner {
 
 							synchronized (JythonReferenceCleaner.this) {
 								// poll the queue
-								JythonEnginePhantomReference ref =
-										(JythonEnginePhantomReference) queue.poll();
+								final JythonEnginePhantomReference ref =
+									(JythonEnginePhantomReference) queue.poll();
 
 								// if we have a ref, clean it up
 								if (ref != null) {
@@ -132,8 +132,8 @@ public class JythonReferenceCleaner {
 
 		public PythonInterpreter interpreter;
 
-		public JythonEnginePhantomReference(JythonScriptEngine engine,
-			ReferenceQueue<JythonScriptEngine> queue)
+		public JythonEnginePhantomReference(final JythonScriptEngine engine,
+			final ReferenceQueue<JythonScriptEngine> queue)
 		{
 			super(engine, queue);
 			interpreter = engine.interpreter;
@@ -141,7 +141,7 @@ public class JythonReferenceCleaner {
 
 		public void cleanup() {
 			final List<String> scriptLocals = new ArrayList<String>();
-			PythonInterpreter interp = interpreter;
+			final PythonInterpreter interp = interpreter;
 			if (interp == null) return;
 
 			// NB: This method for cleaning up local variables was taken from:

--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonReferenceCleaner.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonReferenceCleaner.java
@@ -68,7 +68,8 @@ public class JythonReferenceCleaner {
 		// to use PhantomReferences because the "scope" of a script extends
 		// beyond its eval method - a consumer may still want to inspect
 		// the state of variables after evaluation.
-		// By using PhantomReferences we are saying that the scope of 
+		//
+		// By using PhantomReferences we are saying that the scope of
 		// script evaluation equals the lifetime of the ScriptEngine.
 		phantomReferences.add(new JythonEnginePhantomReference(engine, queue));
 
@@ -77,6 +78,7 @@ public class JythonReferenceCleaner {
 		// threads that would need to be interrupted - instead only starting
 		// threads running when there is actually a PhantomReference that
 		// will eventually be enqueued.
+		//
 		// Here we check if there is already a polling thread in operation -
 		// if not, we start a new thread.
 		if (phantomReferences.size() == 1) {
@@ -144,19 +146,24 @@ public class JythonReferenceCleaner {
 
 			// NB: This method for cleaning up local variables was taken from:
 			// http://python.6.x6.nabble.com/Cleaning-up-PythonInterpreter-object-td1777184.html
-			// Because Python is an interpreted language, when a Python script creates new
-			// variables they stick around in a static org.python.core.PySystemState  variable
-			// (defaultSystemState) the org.python.core.Py class.
-			// Thus an implicit static state is created by script evaluation, so we must manually
-			// clean up local variables known to the interpreter when the scope of an executed
-			// script is over.
-			// See original bug report for the memory leak that prompted this solution:
+			//
+			// Because Python is an interpreted language, when a Python script
+			// creates new variables they stick around in a static
+			// org.python.core.PySystemState variable (defaultSystemState)
+			// the org.python.core.Py class.
+			//
+			// Thus an implicit static state is created by script evaluation,
+			// so we must manually clean up local variables known to the
+			// interpreter when the scope of an executed script is over.
+			//
+			// See original bug report for the leak that prompted this solution:
 			// http://fiji.sc/bugzilla/show_bug.cgi?id=1203
+
 			final PyObject locals = interp.getLocals();
 			for (final PyObject item : locals.__iter__().asIterable()) {
 				final String localVar = item.toString();
-				// Ignore __name__ and __doc__ variables, which are special and known not
-				// to be local variables created by evaluation.
+				// Ignore __name__ and __doc__ variables, which are special
+				// and known not to be local variables created by evaluation.
 				if (!localVar.contains("__name__") && !localVar.contains("__doc__")) {
 					// Build list of variables to clean
 					scriptLocals.add(item.toString());

--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonScriptLanguage.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonScriptLanguage.java
@@ -31,18 +31,11 @@
 
 package org.scijava.plugins.scripting.jython;
 
-import java.lang.ref.PhantomReference;
-import java.lang.ref.ReferenceQueue;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-
 import javax.script.ScriptEngine;
 
 import org.python.core.PyNone;
 import org.python.core.PyObject;
 import org.python.core.PyString;
-import org.python.util.PythonInterpreter;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -60,14 +53,7 @@ import org.scijava.thread.ThreadService;
 @Plugin(type = ScriptLanguage.class, name = "Python")
 public class JythonScriptLanguage extends AdaptedScriptLanguage {
 
-	// List of PhantomReferences and corresponding ReferenceQueue to
-	// facilitate proper PhantomReference use.
-	// See http://resources.ej-technologies.com/jprofiler/help/doc/index.html
-
-	private final LinkedList<JythonEnginePhantomReference> phantomReferences =
-		new LinkedList<JythonEnginePhantomReference>();
-	private final ReferenceQueue<JythonScriptEngine> queue =
-		new ReferenceQueue<JythonScriptEngine>();
+	private JythonReferenceCleaner cleaner = new JythonReferenceCleaner();
 
 	@Parameter
 	private ThreadService threadService;
@@ -83,64 +69,7 @@ public class JythonScriptLanguage extends AdaptedScriptLanguage {
 	public ScriptEngine getScriptEngine() {
 		// TODO: Consider adapting the wrapped ScriptEngineFactory's ScriptEngine.
 		final JythonScriptEngine engine = new JythonScriptEngine();
-		final LogService ls = logService;
-
-		synchronized (phantomReferences) {
-			// NB: This phantom reference is used to clean up any local variables
-			// created by evaluation of scripts via this ScriptEngine. We need
-			// to use PhantomReferences because the "scope" of a script extends
-			// beyond its eval method - a consumer may still want to inspect
-			// the state of variables after evaluation.
-			// By using PhantomReferences we are saying that the scope of 
-			// script evaluation equals the lifetime of the ScriptEngine.
-			phantomReferences.add(new JythonEnginePhantomReference(engine, queue));
-
-			// NB: The use of PhantomReferences requires a paired polling thread.
-			// We poll instead of blocking for input to avoid leaving lingering
-			// threads that would need to be interrupted - instead only starting
-			// threads running when there is actually a PhantomReference that
-			// will eventually be enqueued.
-			// Here we check if there is already a polling thread in operation -
-			// if not, we start a new thread.
-			if (phantomReferences.size() == 1) {
-				threadService.run(new Runnable() {
-
-					@Override
-					public void run() {
-						boolean done = false;
-
-						// poll the queue
-						while (!done) {
-							try {
-								Thread.sleep(100);
-
-								synchronized (phantomReferences) {
-									// poll the queue
-									JythonEnginePhantomReference ref =
-										(JythonEnginePhantomReference) queue.poll();
-
-									// if we have a ref, clean it up
-									if (ref != null) {
-										ref.cleanup();
-										phantomReferences.remove(ref);
-									}
-
-									// Once we're done with our known phantom refs
-									// we can let this thread shut down
-									done = phantomReferences.size() == 0;
-								}
-
-							}
-							catch (final Exception ex) {
-								// log exception, continue
-								ls.error(ex);
-							}
-						}
-					}
-				});
-
-			}
-		}
+		cleaner.queueCleanup(engine, threadService, logService);
 		return engine;
 	}
 
@@ -159,52 +88,4 @@ public class JythonScriptLanguage extends AdaptedScriptLanguage {
 		return object;
 	}
 
-	/**
-	 * Helper class to clean up {@link PythonInterpreter} local variables when a
-	 * parent {@link JythonScriptEngine} leaves scope.
-	 */
-	private static class JythonEnginePhantomReference extends
-		PhantomReference<JythonScriptEngine>
-	{
-
-		public PythonInterpreter interpreter;
-
-		public JythonEnginePhantomReference(JythonScriptEngine engine,
-			ReferenceQueue<JythonScriptEngine> queue)
-		{
-			super(engine, queue);
-			interpreter = engine.interpreter;
-		}
-
-		public void cleanup() {
-			final List<String> scriptLocals = new ArrayList<String>();
-			PythonInterpreter interp = interpreter;
-			if (interp == null) return;
-
-			// NB: This method for cleaning up local variables was taken from:
-			// http://python.6.x6.nabble.com/Cleaning-up-PythonInterpreter-object-td1777184.html
-			// Because Python is an interpreted language, when a Python script creates new
-			// variables they stick around in a static org.python.core.PySystemState  variable
-			// (defaultSystemState) the org.python.core.Py class.
-			// Thus an implicit static state is created by script evaluation, so we must manually
-			// clean up local variables known to the interpreter when the scope of an executed
-			// script is over.
-			// See original bug report for the memory leak that prompted this solution:
-			// http://fiji.sc/bugzilla/show_bug.cgi?id=1203
-			final PyObject locals = interp.getLocals();
-			for (final PyObject item : locals.__iter__().asIterable()) {
-				final String localVar = item.toString();
-				// Ignore __name__ and __doc__ variables, which are special and known not
-				// to be local variables created by evaluation.
-				if (!localVar.contains("__name__") && !localVar.contains("__doc__")) {
-					// Build list of variables to clean
-					scriptLocals.add(item.toString());
-				}
-			}
-			// Null out local variables
-			for (final String string : scriptLocals) {
-				interp.set(string, null);
-			}
-		}
-	}
 }

--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonScriptLanguage.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonScriptLanguage.java
@@ -43,6 +43,7 @@ import org.python.core.PyNone;
 import org.python.core.PyObject;
 import org.python.core.PyString;
 import org.python.util.PythonInterpreter;
+import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.script.AdaptedScriptLanguage;
@@ -71,6 +72,9 @@ public class JythonScriptLanguage extends AdaptedScriptLanguage {
 	@Parameter
 	private ThreadService threadService;
 
+	@Parameter
+	private LogService logService;
+
 	public JythonScriptLanguage() {
 		super("jython");
 	}
@@ -79,6 +83,7 @@ public class JythonScriptLanguage extends AdaptedScriptLanguage {
 	public ScriptEngine getScriptEngine() {
 		// TODO: Consider adapting the wrapped ScriptEngineFactory's ScriptEngine.
 		final JythonScriptEngine engine = new JythonScriptEngine();
+		final LogService ls = logService;
 
 		synchronized (phantomReferences) {
 			// NB: This phantom reference is used to clean up any local variables
@@ -128,6 +133,7 @@ public class JythonScriptLanguage extends AdaptedScriptLanguage {
 							}
 							catch (final Exception ex) {
 								// log exception, continue
+								ls.error(ex);
 							}
 						}
 					}


### PR DESCRIPTION
Jython eval acts like an interpreter - any intermittently declared variables can be preserved. The PythonInterpreter is also frustratingly persistent and resists clean-up attempts.

This has led to a memory leak in our Jython script language (see http://fiji.sc/bugzilla/show_bug.cgi?id=1203).

To fix this, a PhantomReference is used to monitor when its corresponding JythonScriptEngine is garbage collected, at which point the PythonInterpreter is forcefully cleaned of local variables.

To avoid mutual hard references, the JythonScriptEngine and containing ScriptModule must never be passed to the PythonInterpreter. Instead, they can be cached in a Java-side map to weak references.