### PR TITLE
Support python (jython) rename syntax highlighting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>27.0.1</version>
+		<version>32.0.0-beta-4</version>
 		<relativePath />
 	</parent>
 
@@ -102,12 +102,20 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-common</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>script-editor</artifactId>
+		</dependency>
 
 		<!-- Third-party dependencies -->
 		<dependency>
 			<groupId>org.python</groupId>
 			<artifactId>jython-slim</artifactId>
 			<version>${jython-slim.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fifesoft</groupId>
+			<artifactId>rsyntaxtextarea</artifactId>
 		</dependency>
 
 		<!-- Test dependencies -->
@@ -117,4 +125,10 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<repositories>
+		<repository>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
+		</repository>
+	</repositories>
 </project>

--- a/src/main/java/org/scijava/plugins/scripting/jython/JythonScriptSyntaxHighlighter.java
+++ b/src/main/java/org/scijava/plugins/scripting/jython/JythonScriptSyntaxHighlighter.java
@@ -1,0 +1,46 @@
+/*
+ * #%L
+ * Python scripting language plugin to be used with PyImageJ.
+ * %%
+ * Copyright (C) 2021 - 2022 SciJava developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package org.scijava.plugins.scripting.jython;
+
+import org.fife.ui.rsyntaxtextarea.modes.PythonTokenMaker;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.swing.script.SyntaxHighlighter;
+
+/**
+ * SyntaxHighlighter for Python (Jython).
+ *
+ * @author Karl Duderstadt
+ */
+@Plugin(type = SyntaxHighlighter.class, name = "python-(jython)")
+public class JythonScriptSyntaxHighlighter extends PythonTokenMaker implements
+SyntaxHighlighter
+{
+	// Everything implemented in PythonTokenMaker
+}


### PR DESCRIPTION
When this language was named Python, syntax highlighting was supported directly using the default python highlighter available in rsyntaxtextarea. The name change to Python (Jython) disrupts this support. To add back syntax highlighting support for the new name, this PR adds two dependencies:
   * org.scijava:script-editor
   * com.fifesoft:rsyntaxtextarea

Also this bumps the pom to version 32.0.0-beta-4 (not required, but I did it). the new class JythonScriptSyntaxHighlighter is added that adds the language name python-(jython) for syntax highlighting using the PythonTokenMaker.

I guess the added dependencies are not ideal, especially the rsyntaxtextarea. I guess there could be other hacky solutions like the current implementation that changes the names so the default highlighters work... 

Changes to autocompletion were also required as a result of this name change. They can be found in this PR https://github.com/scijava/script-editor-jython/pull/17. 

What should be do?